### PR TITLE
Strict order for alter owner queries

### DIFF
--- a/adapter/basic/basic_roles.go
+++ b/adapter/basic/basic_roles.go
@@ -199,18 +199,18 @@ func (sa ServiceAdapter) GrantUsersAccordingRoles(ctx context.Context, dbName st
 		}
 		if isOwnerChanged {
 			// altering owners for DB resources
-			alterOperations := map[string]func(string, string, string) string{
-				getTablesListQuery(schema, isExternalPg):      alterOwnerForTable,
-				getSequenceListQuery(schema, isExternalPg):    alterOwnerForSequence,
-				getLargeObjectsListQuery(isExternalPg):        alterOwnerForLargeObject,
-				getViewsListQuery(schema, isExternalPg):       alterViewOwnerQuery,
-				getFunctionsListQuery(schema, isExternalPg):   alterFunctionOwnerQuery,
-				getProceduresListQuery(schema, isExternalPg):  alterProcedureOwnerQuery,
-				getCustomTypesListQuery(schema, isExternalPg): alterTypeOwnerQuery,
+			alterOperations := []DbResource{
+				{getTablesListQuery(schema, isExternalPg), alterOwnerForTable},
+				{getSequenceListQuery(schema, isExternalPg), alterOwnerForSequence},
+				{getLargeObjectsListQuery(isExternalPg), alterOwnerForLargeObject},
+				{getViewsListQuery(schema, isExternalPg), alterViewOwnerQuery},
+				{getFunctionsListQuery(schema, isExternalPg), alterFunctionOwnerQuery},
+				{getProceduresListQuery(schema, isExternalPg), alterProcedureOwnerQuery},
+				{getCustomTypesListQuery(schema, isExternalPg), alterTypeOwnerQuery},
 			}
 
-			for resourceQuery, alterQuery := range alterOperations {
-				alterOwnerQueries, errCh := sa.executeForResourceQueries(ctx, schema, dbName, metadataOwner, resourceQuery, alterQuery)
+			for _, dbResource := range alterOperations {
+				alterOwnerQueries, errCh := sa.executeForResourceQueries(ctx, schema, dbName, metadataOwner, dbResource.SelectQuery, dbResource.AlterQueryFunction)
 				if errCh != nil {
 					return errCh
 				}

--- a/adapter/basic/type.go
+++ b/adapter/basic/type.go
@@ -56,3 +56,8 @@ type SettingUpdateResult struct {
 type DbInfo struct {
 	Owner string `json:"owner"`
 }
+
+type DbResource struct {
+	SelectQuery        string
+	AlterQueryFunction func(string, string, string) string
+}


### PR DESCRIPTION
Order is important due to sequences linked to tables. Table owner in this case must be changed first.